### PR TITLE
[TL] Renames Utf8Mi[n]eType to Utf8MimeTypes

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/microservice/controller/BaseController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/microservice/controller/BaseController.scala
@@ -24,7 +24,7 @@ import play.api.mvc.Result
 import play.api.libs.json.{JsError, JsSuccess, Reads, JsValue}
 import scala.util.{Failure, Success, Try}
 
-trait Utf8MineTypes {
+trait Utf8MimeTypes {
   self : Controller =>
 
   override def JSON(implicit codec: Codec) = s"${MimeTypes.JSON};charset=utf-8"
@@ -32,7 +32,7 @@ trait Utf8MineTypes {
   override def HTML(implicit codec: Codec) = s"${MimeTypes.HTML};charset=utf-8"
 }
 
-trait BaseController extends Controller with Utf8MineTypes {
+trait BaseController extends Controller with Utf8MimeTypes {
 
   implicit def hc(implicit rh: RequestHeader) = HeaderCarrier.fromHeadersAndSession(rh.headers)
 

--- a/src/test/scala/uk/gov/hmrc/play/microservice/controller/Utf8MimeTypesSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/microservice/controller/Utf8MimeTypesSpec.scala
@@ -20,7 +20,7 @@ import org.scalatest.{Matchers, WordSpecLike}
 import play.api.mvc.{Codec, Controller}
 
 
-class Utf8MineTypesSpec extends WordSpecLike with Matchers {
+class Utf8MimeTypesSpec extends WordSpecLike with Matchers {
 
   implicit val codec = Codec.utf_8
 
@@ -36,7 +36,7 @@ class Utf8MineTypesSpec extends WordSpecLike with Matchers {
 
     "have application json with utf8 character set" in {
 
-      val controller = new Controller with Utf8MineTypes {}
+      val controller = new Controller with Utf8MimeTypes {}
       val applicationJsonWithUtf8Charset = controller.JSON
 
       applicationJsonWithUtf8Charset shouldBe "application/json;charset=utf-8"
@@ -44,7 +44,7 @@ class Utf8MineTypesSpec extends WordSpecLike with Matchers {
 
     "have text html with utf8 character set" in {
 
-      val controller = new Controller with Utf8MineTypes {}
+      val controller = new Controller with Utf8MimeTypes {}
       val textHtmlWithUtf8Charset = controller.HTML
 
       textHtmlWithUtf8Charset shouldBe "text/html;charset=utf-8"


### PR DESCRIPTION
Renames trait Utf8Mi[n]eTypes with typo in the name to *Mime types
