### PR TITLE
TXMNT-366 Update play-filters and remove PlayException handling

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -33,7 +33,7 @@ object Dependencies {
 
   val compile = Seq(
     filters,
-    "uk.gov.hmrc" %% "play-filters" % "5.3.0",
+    "uk.gov.hmrc" %% "play-filters" % "5.4.0",
     "uk.gov.hmrc" %% "play-graphite" % "3.0.0",
     "com.typesafe.play" %% "play" % "2.5.8",
     "de.threedimensions" %% "metrics-play" % "2.5.13",

--- a/src/main/scala/uk/gov/hmrc/play/microservice/bootstrap/JsonErrorHandling.scala
+++ b/src/main/scala/uk/gov/hmrc/play/microservice/bootstrap/JsonErrorHandling.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.play.microservice.bootstrap
 
-import scala.concurrent.Future
-
-import play.api.mvc.RequestHeader
-import play.api.libs.json.Json
 import play.api.GlobalSettings
 import play.api.http.Status._
+import play.api.libs.json.Json
+import play.api.mvc.RequestHeader
 import play.api.mvc.Results._
-import uk.gov.hmrc.play.http._
+import uk.gov.hmrc.play.http.{HttpException, Upstream4xxResponse, Upstream5xxResponse}
+
+import scala.concurrent.Future
 
 case class ErrorResponse(statusCode: Int, message: String, xStatusCode: Option[String] = None, requested: Option[String] = None)
 
@@ -33,7 +33,7 @@ trait JsonErrorHandling extends GlobalSettings {
 
   override def onError(request: RequestHeader, ex: Throwable) = {
     Future.successful {
-      val (code, message) = ex.getCause match {
+      val (code, message) = ex match {
         case e: HttpException => (e.responseCode, e.getMessage)
 
         case e: Upstream4xxResponse => (e.reportAs, e.getMessage)

--- a/src/test/scala/uk/gov/hmrc/play/microservice/bootstrap/DefaultMicroserviceGlobalSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/microservice/bootstrap/DefaultMicroserviceGlobalSpec.scala
@@ -55,7 +55,7 @@ class DefaultMicroserviceGlobalSpec extends WordSpecLike with Matchers with Scal
 
     "send an event to DataStream and return 404 status code for a NotFoundException" in {
       val restGlobal = new TestRestGlobal()
-      val resultF = restGlobal.onError(requestHeader, new PlayException("", "", new NotFoundException("test"))).futureValue
+      val resultF = restGlobal.onError(requestHeader, new NotFoundException("test")).futureValue
 
       resultF.header.status shouldBe 404
       restGlobal.auditConnector.recordedEvent shouldNot be(None)

--- a/src/test/scala/uk/gov/hmrc/play/microservice/bootstrap/JsonErrorHandlingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/microservice/bootstrap/JsonErrorHandlingSpec.scala
@@ -32,24 +32,25 @@ class JsonErrorHandlingSpec extends WordSpecLike with Matchers with ScalaFutures
   "error handling in onError function" should {
 
     "convert a NotFoundException to NotFound response" in {
-      val resultF = jsh.onError(requestHeader, new PlayException("", "", new NotFoundException("test"))).futureValue
+      val resultF = jsh.onError(requestHeader, new NotFoundException("test")).futureValue
       resultF.header.status shouldBe 404
     }
 
     "convert a BadRequestException to NotFound response" in {
-      val resultF = jsh.onError(requestHeader, new PlayException("", "", new BadRequestException("bad request"))).futureValue
+      val resultF = jsh.onError(requestHeader, new BadRequestException("bad request")).futureValue
       resultF.header.status shouldBe 400
     }
 
     "convert an UnauthorizedException to Unauthorized response" in {
-      val resultF = jsh.onError(requestHeader, new PlayException("", "", new UnauthorizedException("unauthorized"))).futureValue
+      val resultF = jsh.onError(requestHeader, new UnauthorizedException("unauthorized")).futureValue
       resultF.header.status shouldBe 401
     }
 
     "convert an Exception to InternalServerError" in {
-      val resultF = jsh.onError(requestHeader, new PlayException("", "", new Exception("any application exception"))).futureValue
+      val resultF = jsh.onError(requestHeader, new Exception("any application exception")).futureValue
       resultF.header.status shouldBe 500
     }
+
 
   }
 }


### PR DESCRIPTION
Play 2.5 no longer wraps service generated exceptions in a PlayException
so the JsonErrorHandling class fails to match on ex.getCause as it is null.

Change the hanlder to match on the provided Throwable instead and update the
test cases.
