### PR TITLE
TXMNT-366 Change defaultMicroserviceFilters from lazy val to def

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/microservice/bootstrap/MicroserviceGlobal.scala
+++ b/src/main/scala/uk/gov/hmrc/play/microservice/bootstrap/MicroserviceGlobal.scala
@@ -37,7 +37,7 @@ trait MicroserviceFilters extends MicroserviceFilterSupport {
 
   def authFilter: Option[EssentialFilter]
 
-  protected lazy val defaultMicroserviceFilters: Seq[EssentialFilter] = Seq(
+  protected def defaultMicroserviceFilters: Seq[EssentialFilter] = Seq(
     Some(metricsFilter),
     Some(microserviceAuditFilter),
     Some(loggingFilter),


### PR DESCRIPTION
This is to avoid tear down issues when running OneServerPerTest